### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A functional tutorial can be found in 'godot_examples/tutorial'.
 
 All IOMapper devices must be stored in a variable and call the init() method in the Godot script's `_ready()` fuction. This is also where all signals should be assigned to the device:
 
-```python
+```GDScript
 Ex. # Creating device and signals     
             
 var dev = IOMapper.new()
@@ -40,7 +40,7 @@ func _ready():
     
 Next, we need to know how to access the signal values:
 
-```python
+```GDScript
 Ex. # Polling the device and accessing signal values
 
 func _process(_delta):


### PR DESCRIPTION
While writing up the mediapipe tutorial for libmapper, I found out that github's markdown does support GDScript highlighting! Small change to `README.md` to use this syntax highlighter.